### PR TITLE
Fix unnecessary apostrophe in check3_urbackup.py

### DIFF
--- a/src/check3_urbackup.py
+++ b/src/check3_urbackup.py
@@ -50,7 +50,7 @@ class Failing_Backup_Context(nagiosplugin.Context):
 
 class Failing_Backup_Summary(nagiosplugin.Summary):
     def problem(self, results):
-        return "failing backups: %s'" % (', '.join(
+        return "failing backups: %s" % (', '.join(
             ["%s.%s failed" % (b[u'client'],b[u'fail'],) for b in results.results[0].resource.failing_backups]
             )
         )


### PR DESCRIPTION
I know this is an old script, but it still works! There is a random apostrophe at the end of the output.